### PR TITLE
Update build-run-remarkable.sh

### DIFF
--- a/build-run-remarkable.sh
+++ b/build-run-remarkable.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 
-dockcross-linux-armv7-rust ./build.sh
-dockcross-linux-armv7-rust ./dist.sh
+../dockcross/dockcross-linux-armv7-rust ./build.sh
+../dockcross/dockcross-linux-armv7-rust ./dist.sh
 
 DEVICE_IP="10.11.99.1"
 ssh root@$DEVICE_IP 'systemctl stop xochitl || true ; killall -9 plato || true; killall -9 draft || true; systemctl stop xochitl || true'


### PR DESCRIPTION
Hi @ddvk I'm trying to build your `plato` fork on my MacOS Catalina 10.15.1 so I can load it into my new reMarkable v2.0.2.0 (I'm at least assuming that v2.0.2.0 is safe for `draft` and `plato`, but running into issues.  I became aware of your fork via your [Reddit comment](https://www.reddit.com/r/RemarkableTablet/comments/bkbps9/how_to_install_plato_reader_and_add_it_to_draft/emfk6b7/)

You made your email address private and I didn't see any other available contact methods, so this is the best I could do to message you to request for assistance.

I cloned https://github.com/darvin/dockcross and tried to retrieve the dockcross/linux-armv7-rust docker image...but no such image apparently exists.

So I did the following to build a local dockcross-linux-armv7-rust docker image:
1. I edited `dockcross/linux-armv7-rust/Dockerfile.in` and change the `DEFAULT_DOCKCROSS_IMAGE` to just `linux-armv7-rust`
1. I then ran the instructions in https://github.com/darvin/dockcross#how-to-extend-dockcross-images to build it locally
1. I then had to edit the `dockcross/linux-armv7-rust` file that I had created and once again had to change this line so that it would not go to DockerHub to get a dockcross docker image, but instead look locally: `DEFAULT_DOCKCROSS_IMAGE=linux-armv7-rust`